### PR TITLE
Soluciona error en la copia de lista con Racket.

### DIFF
--- a/material/capítulo_12/ejemplos/funciones-puras-copy-list.rkt
+++ b/material/capítulo_12/ejemplos/funciones-puras-copy-list.rkt
@@ -1,11 +1,10 @@
 #lang racket
 (define copy-list
   (lambda (lst)
-    (cond
-      [(null? lst) '()]
-      [(list? lst)
-       (cons (copy-list (car lst)) (copy-list (cdr lst)))
-       lst]
-      )))
+    (cond [(null? lst) '()]
+	  [(list? lst) (cons (car lst)
+			     (copy-list (cdr lst)))])))
 (equal? '(1 2 3) (copy-list '(1 2 3)))
 ; #t
+(eq? '(1 2 3) (copy-list '(1 2 3)))
+; #f


### PR DESCRIPTION
No se estaba creando una lista, sino devolviendo la misma lista que se
recibía como argumento. Se puede comprobar con la función `eq?`. La he
añadido para que se vea que la funcíon `equal?` devuelve `#t`, pues
ambas listas tienen el mismo contenido, pero `eq?` devuelve `#f`, ya
que no es el mismo objeto.